### PR TITLE
adding basic annotation functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ ENV/
 # Rope project settings
 .ropeproject
 
+# PyCharm project settings
+.idea
+
 # temp files
 *.swp
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Installs the editable version
 install: uninstall package
-	pip3 install -U -e $(CURDIR)
+	pip3 install -e $(CURDIR)
 
 # Installs the packaged version
 testpackage: uninstall package
@@ -15,7 +15,7 @@ package: clean doc
 uninstall:
 	pip3 freeze | grep cvloop > /dev/null ; \
 	if [ $$? -eq 0 ]; then \
-		pip uninstall cvloop -y ; \
+		pip3 uninstall cvloop -y ; \
 	fi
 
 # Cleans up: Removes the packed package and sanitizes the examples file.

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ testpackage: uninstall package
 
 # Packs the package into the dist directory and signs it
 package: clean doc
-	python setup.py sdist
+	python3 setup.py sdist
 	gpg --detach-sign --armor dist/cvloop*.tar.gz
 
 # Uninstalls the package from a local installation
@@ -21,11 +21,11 @@ uninstall:
 # Cleans up: Removes the packed package and sanitizes the examples file.
 clean:
 	rm -rf dist
-	python tools/sanitize_ipynb.py examples/cvloop_examples.ipynb
+	python3 tools/sanitize_ipynb.py examples/cvloop_examples.ipynb
 
 # Creates the documentation and updates the functions ipynb.
 doc:
-	python tools/create_functions_ipynb.py  examples/cvloop_functions.ipynb
+	python3 tools/create_functions_ipynb.py  examples/cvloop_functions.ipynb
 
 # Publishes to pypitest
 testpublish: package

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # Installs the editable version
 install: uninstall package
-	pip install -e $(CURDIR)
+	pip3 install -U -e $(CURDIR)
 
 # Installs the packaged version
 testpackage: uninstall package
-	pip install dist/cvloop*.tar.gz
+	pip3 install dist/cvloop*.tar.gz
 
 # Packs the package into the dist directory and signs it
 package: clean doc
@@ -13,7 +13,7 @@ package: clean doc
 
 # Uninstalls the package from a local installation
 uninstall:
-	pip freeze | grep cvloop > /dev/null ; \
+	pip3 freeze | grep cvloop > /dev/null ; \
 	if [ $$? -eq 0 ]; then \
 		pip uninstall cvloop -y ; \
 	fi

--- a/README.rst
+++ b/README.rst
@@ -37,15 +37,11 @@ Requirements
 
 (Recommended versions, additionally tested versions in parentheses.)
 
--  Python 3.6 (Required)
+-  Python 3.6
 -  OpenCV 3.2
 -  Jupyter 4.3.1
-
-Dependencies
-------------
-
--  matplotlib (2.0.0)
--  numpy (1.12.0)
+-  matplotlib 2.0.0
+-  numpy 1.12.0
 
 .. _`OpenCV Documentation`: http://docs.opencv.org/3.1.0/db/d5c/tutorial_py_bg_subtraction.html
 .. _`Video`: https://github.com/opencv/opencv_extra/tree/master/testdata/cv/video

--- a/cvloop/cvloop.py
+++ b/cvloop/cvloop.py
@@ -32,7 +32,7 @@ class cvloop(animation.TimedAnimation):
                  side_by_side=False, convert_color=cv2.COLOR_BGR2RGB,
                  cmaps=None, print_info=False, annotations=None,
                  annotations_default={'shape': 'RECT',
-                                      'color': (0.5, 0.9, 0.0),
+                                      'color': '#228B22',
                                       'line': 2,
                                       'size': (20, 20)}):
         """Runs a video loop for the specified source and modifies the stream
@@ -93,7 +93,7 @@ class cvloop(animation.TimedAnimation):
                     specific format is given for an annotation. If no format is
                     specified the following defaults are used:
                         shape: 'RECT',
-                        color: '#008000', (dark green)
+                        color: '#228B22', (forestgreen)
                         line: 2,
                         size: (20, 20)
         """

--- a/cvloop/cvloop.py
+++ b/cvloop/cvloop.py
@@ -30,7 +30,11 @@ class cvloop(animation.TimedAnimation):
 
     def __init__(self, source=None, function=lambda x: x, *,
                  side_by_side=False, convert_color=cv2.COLOR_BGR2RGB,
-                 cmaps=None, print_info=False, annotations=None):
+                 cmaps=None, print_info=False, annotations=None,
+                 annotations_default={'shape': 'RECT',
+                                      'color': (0.5, 0.9, 0.0),
+                                      'line': 2,
+                                      'size': (20, 20)}):
         """Runs a video loop for the specified source and modifies the stream
         with the function.
 
@@ -81,13 +85,17 @@ class cvloop(animation.TimedAnimation):
                          options: A dictionary. This is optional (leaving the
                              list with only three elements). Allows the
                              following keys:
-                             shape: 'RECT' or 'CIRC' (rectangle, circle;
-                                    default: RECT)
-                             line: linewidth (default: 2)
-                             color: RGB tuple or gray scalar
-                                    (default: (1, 0, 0), i.e. bright red)
+                             shape: 'RECT' or 'CIRC' (rectangle, circle)
+                             line: linewidth
+                             color: RGB tuple, gray scalar or html hex-string
                              size: radius for CIRC, (width, height) for RECT
-                                    (default: 30; (40, 30) )
+            annotations_default: A default format, that will be used if no specific
+                                format is given for an annotation. If no format is specified
+                                the following defaults are used:
+                                shape: 'RECT',
+                                color: '#008000', (dark green)
+                                line: 2,
+                                size: (20, 20)
         """
         if source is not None:
             if isinstance(source, type(cv2.VideoCapture())) \
@@ -108,6 +116,7 @@ class cvloop(animation.TimedAnimation):
 
         self.annotations = (None if not annotations else
                             sorted(annotations, key=lambda a: a[2]))
+        self.annotations_default = annotations_default
         self.annotation_artists = []
 
         self.original = None
@@ -328,10 +337,10 @@ class cvloop(animation.TimedAnimation):
                 return
             if annotation[2] == frame_no:
                 pos = annotation[0:2]
-                shape = 'RECT'
-                color = (1, 0, 0)
-                size = (40, 30)
-                line = 2
+                shape = self.annotations_default['shape']
+                color = self.annotations_default['color']
+                size = self.annotations_default['size']
+                line = self.annotations_default['line']
                 if len(annotation) > 3:
                     if 'shape' in annotation[3]:
                         shape = annotation[3]['shape']
@@ -355,9 +364,8 @@ class cvloop(animation.TimedAnimation):
                 elif shape == 'CIRC':
                     patch = patches.CirclePolygon(pos, radius=size, fc='none',
                                                   ec=color, lw=line)
-                self.annotation_artists.append(
-                    patch
-                )
+                self.annotation_artists.append(patch
+)
                 self.axes_processed.add_artist(self.annotation_artists[-1])
 
     def _draw_frame(self, frame_no):

--- a/cvloop/cvloop.py
+++ b/cvloop/cvloop.py
@@ -89,13 +89,13 @@ class cvloop(animation.TimedAnimation):
                              line: linewidth
                              color: RGB tuple, gray scalar or html hex-string
                              size: radius for CIRC, (width, height) for RECT
-            annotations_default: A default format, that will be used if no specific
-                                format is given for an annotation. If no format is specified
-                                the following defaults are used:
-                                shape: 'RECT',
-                                color: '#008000', (dark green)
-                                line: 2,
-                                size: (20, 20)
+            annotations_default: A default format, that will be used if no
+                    specific format is given for an annotation. If no format is
+                    specified the following defaults are used:
+                        shape: 'RECT',
+                        color: '#008000', (dark green)
+                        line: 2,
+                        size: (20, 20)
         """
         if source is not None:
             if isinstance(source, type(cv2.VideoCapture())) \
@@ -364,8 +364,7 @@ class cvloop(animation.TimedAnimation):
                 elif shape == 'CIRC':
                     patch = patches.CirclePolygon(pos, radius=size, fc='none',
                                                   ec=color, lw=line)
-                self.annotation_artists.append(patch
-)
+                self.annotation_artists.append(patch)
                 self.axes_processed.add_artist(self.annotation_artists[-1])
 
     def _draw_frame(self, frame_no):

--- a/examples/cvloop_examples.ipynb
+++ b/examples/cvloop_examples.ipynb
@@ -17,7 +17,8 @@
                 "1. [Custom color map](#Custom-color-map)\n",
                 "1. [Multiple custom color maps](#Multiple-custom-color-maps)\n",
                 "1. [Complex VideoCapture source](#Complex-VideoCapture-source)\n",
-                "1. [Alternative video source](#Alternative-video-source)"
+                "1. [Alternative video source](#Alternative-video-source)\n",
+                "1. [Video annotations](#Video-annotations)"
             ]
         },
         {
@@ -399,6 +400,65 @@
                 "custom_source = MySource()\n",
                 "cvloop(source=custom_source, cmaps='terrain')"
             ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## Video annotations\n",
+                "\n",
+                "*This feature is still experimental!*\n",
+                "\n",
+                "It is possible to add annotations to the processed image.\n",
+                "Annotations can either be rectangles (`RECT`) or circles (`CIRC`).\n",
+                "\n",
+                "To use annotations, provide a list of annotations following this format:\n",
+                "\n",
+                "    [x, y, frame, options]\n",
+                "    \n",
+                "Where `x` and `y` are the center coordinates of the annotation and `frame` is the frame number for the annotation to be shown. `options` is an optional parameter. It is a dictionary with any of the following properties:\n",
+                "\n",
+                "- `shape`: Either `CIRC` or `RECT`. Determines the shape of the annotation. Defaults to `RECT`.\n",
+                "- `color`: Either a scalar value (gray scale) or an RGB tuple (r, g, b). All values must be between 0 and 1. Determines the color of the annotation. Defaults to `(1, 0, 0)` (bright red).\n",
+                "- `line`: The line width of the annotation. Defaults to `2`.\n",
+                "- `size`: The size of the annotation. For circles (`CIRC`) this should be a scalar value for the radius (default: `30`). For rectangles (`RECT`) this should be a tuple `(width, height)` (default: `(40, 30)`)."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from cvloop import cvloop\n",
+                "\n",
+                "annotations = []\n",
+                "\n",
+                "# Show all annotations from frames 10 to 79\n",
+                "for i in range(10, 80):\n",
+                "    # Red rectangle moving from left to right\n",
+                "    annotations.append([i * 5 + 40, 50, i])\n",
+                "    # Gray circle\n",
+                "    annotations.append([250, 140, i, {'shape': 'CIRC', 'color': .8}])\n",
+                "\n",
+                "    # Violett rectangle with all rectangle properties set:\n",
+                "    annotations.append([300, 250, i, {\n",
+                "        'shape': 'RECT',\n",
+                "        'color': (0.3, 0.2, 0.8),\n",
+                "        'line': 4,\n",
+                "        'size': (30, 80)\n",
+                "    }])\n",
+                "\n",
+                "    # Orange circle with all circle properties set:\n",
+                "    annotations.append([450, 300, i, {\n",
+                "        'shape': 'CIRC',\n",
+                "        'color': (1, 0.5, 0.1),\n",
+                "        'line': 1,\n",
+                "        'size': 40\n",
+                "    }])\n",
+                "\n",
+                "cvloop('768x576.avi', annotations=annotations)"
+            ]
         }
     ],
     "metadata": {
@@ -412,7 +472,7 @@
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.6.0"
+            "version": "3.6.1"
         }
     },
     "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from distutils.core import setup
 
 import re

--- a/tools/sanitize_ipynb.py
+++ b/tools/sanitize_ipynb.py
@@ -21,8 +21,8 @@ def main():
         try:
             if cell['cell_type'] == 'code':
                 cell['outputs'] = []
-                cell['metadata'] = {}
                 cell['execution_count'] = None
+            cell['metadata'] = {}
         except KeyError:
             pass
 


### PR DESCRIPTION
Allows to add annotations as requested in #13.

Annotations are of this form: `[x, y, frame, {'shape': 'RECT', 'color': (0.3, 0.2, 0.8), 'line': 3, 'size': (30, 80)}]` and can be supplied as a list. For more details please refer to the documentation in the example notebook.